### PR TITLE
security(server): mitigate CWE-22 path traversal in static file server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,21 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+  server-security-test:
+    name: Server Path Traversal Regression
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+
+      - name: Run path traversal regression suite
+        run: node scripts/test-path-traversal.mjs
+
   validate-docs:
     name: Validate Documentation
     runs-on: ubuntu-latest
@@ -127,7 +142,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint-and-typecheck, test, validate-docs]
+    needs: [lint-and-typecheck, test, server-security-test, validate-docs]
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "changeset:status": "changeset status",
     "heroku-postbuild": "corepack enable && pnpm install --frozen-lockfile && DOCS_BASE_PATH=/docs/ pnpm run build && cp -r apps/docs/build apps/ui/dist/docs",
     "start": "node server.mjs",
-    "test:server": "node scripts/test-path-traversal.mjs",
+    "test:server-path-traversal": "node scripts/test-path-traversal.mjs",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "changeset:status": "changeset status",
     "heroku-postbuild": "corepack enable && pnpm install --frozen-lockfile && DOCS_BASE_PATH=/docs/ pnpm run build && cp -r apps/docs/build apps/ui/dist/docs",
     "start": "node server.mjs",
+    "test:server": "node scripts/test-path-traversal.mjs",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/test-path-traversal.mjs
+++ b/scripts/test-path-traversal.mjs
@@ -1,0 +1,240 @@
+/*
+ * Regression test for path traversal (CWE-22) in server.mjs.
+ *
+ * Boots the real server.mjs (so future regressions to that file are caught),
+ * then issues a series of HTTP requests covering:
+ *   - baseline (must be served)
+ *   - traversal payloads with the WHATWG-bypassing encodings
+ *     (..%2f..%2f..%2f and %2e%2e%2f%2e%2e%2f%2e%2e%2f)
+ *   - negative controls that the URL parser already normalizes
+ *
+ * A traversal "passes" only if the server does NOT return the contents of a
+ * file outside the static dir. Exit code 0 = mitigated, 1 = vulnerable.
+ *
+ * Run with: node scripts/test-path-traversal.mjs
+ */
+
+import { spawn } from 'node:child_process';
+import { request } from 'node:http';
+import { mkdir, writeFile, rename, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const STATIC_DIR = join(REPO_ROOT, 'apps', 'ui', 'dist');
+const STUB_INDEX = join(STATIC_DIR, 'index.html');
+const BACKUP_INDEX = join(STATIC_DIR, 'index.html.regression-backup');
+const BASELINE_MARKER = 'AGENTSCRIPT-PATH-TRAVERSAL-BASELINE';
+const PORT = 8765;
+const HOST = '127.0.0.1';
+
+// Hermetic setup: always run the test against a known stub index.html,
+// regardless of whether a previous `pnpm build` has already populated
+// apps/ui/dist/. The original index.html (if any) is moved aside and
+// restored during teardown so we never destroy a developer's build.
+const state = { createdDist: false, backedUpIndex: false, wroteStub: false };
+
+async function setupStaticDir() {
+  if (!existsSync(STATIC_DIR)) {
+    await mkdir(STATIC_DIR, { recursive: true });
+    state.createdDist = true;
+  }
+  if (existsSync(STUB_INDEX)) {
+    await rename(STUB_INDEX, BACKUP_INDEX);
+    state.backedUpIndex = true;
+  }
+  await writeFile(
+    STUB_INDEX,
+    `<!doctype html><html><body>${BASELINE_MARKER}</body></html>\n`
+  );
+  state.wroteStub = true;
+}
+
+async function teardownStaticDir() {
+  if (state.wroteStub) {
+    await rm(STUB_INDEX, { force: true });
+  }
+  if (state.backedUpIndex) {
+    await rename(BACKUP_INDEX, STUB_INDEX);
+  }
+  if (state.createdDist) {
+    await rm(STATIC_DIR, { recursive: true, force: true });
+  }
+}
+
+function httpGet(path) {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      { hostname: HOST, port: PORT, path, method: 'GET' },
+      res => {
+        const chunks = [];
+        res.on('data', c => chunks.push(c));
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode,
+            body: Buffer.concat(chunks).toString('utf-8'),
+          })
+        );
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function waitForServer(maxMs = 5000) {
+  const start = Date.now();
+  while (Date.now() - start < maxMs) {
+    try {
+      await httpGet('/');
+      return;
+    } catch {
+      await sleep(100);
+    }
+  }
+  throw new Error(
+    `server did not respond on ${HOST}:${PORT} within ${maxMs}ms`
+  );
+}
+
+const cases = [
+  {
+    name: 'baseline: GET / serves static index.html',
+    path: '/',
+    mustContain: BASELINE_MARKER,
+    kind: 'baseline',
+  },
+  {
+    name: 'traversal: half-encoded (..%2f) -> package.json',
+    path: '/..%2f..%2f..%2fpackage.json',
+    mustNotContain: '"agentscript-monorepo"',
+    kind: 'traversal',
+  },
+  {
+    name: 'traversal: full-encoded (%2e%2e%2f) -> package.json',
+    path: '/%2e%2e%2f%2e%2e%2f%2e%2e%2fpackage.json',
+    mustNotContain: '"agentscript-monorepo"',
+    kind: 'traversal',
+  },
+  {
+    name: 'traversal: half-encoded -> Procfile',
+    path: '/..%2f..%2f..%2fProcfile',
+    mustNotContain: 'web: node server.mjs',
+    kind: 'traversal',
+  },
+  {
+    name: 'traversal: half-encoded -> LICENSE.txt',
+    path: '/..%2f..%2f..%2fLICENSE.txt',
+    mustNotContain: 'Apache License',
+    kind: 'traversal',
+  },
+  {
+    name: 'control: literal ../ (URL parser normalizes)',
+    path: '/../../../package.json',
+    mustNotContain: '"agentscript-monorepo"',
+    kind: 'control',
+  },
+  {
+    name: 'control: %2e%2e/ with literal slash (URL parser normalizes)',
+    path: '/%2e%2e/%2e%2e/%2e%2e/package.json',
+    mustNotContain: '"agentscript-monorepo"',
+    kind: 'control',
+  },
+];
+
+async function main() {
+  await setupStaticDir();
+
+  const server = spawn(process.execPath, [join(REPO_ROOT, 'server.mjs')], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, PORT: String(PORT) },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let serverLog = '';
+  server.stdout.on('data', c => {
+    serverLog += c.toString();
+  });
+  server.stderr.on('data', c => {
+    serverLog += c.toString();
+  });
+
+  const failures = [];
+
+  try {
+    await waitForServer();
+
+    console.log('='.repeat(72));
+    console.log('  Path traversal regression — server.mjs');
+    console.log(`  Bound: http://${HOST}:${PORT}   STATIC_DIR=${STATIC_DIR}`);
+    console.log('='.repeat(72));
+
+    for (const c of cases) {
+      const res = await httpGet(c.path);
+      const ok = c.mustContain
+        ? res.body.includes(c.mustContain)
+        : !res.body.includes(c.mustNotContain);
+      const tag = ok
+        ? 'PASS'
+        : c.kind === 'traversal'
+          ? 'FAIL — VULNERABLE'
+          : c.kind === 'baseline'
+            ? 'FAIL — BASELINE BROKEN'
+            : 'FAIL';
+      console.log(`  [${tag.padEnd(20)}] ${c.name}`);
+      console.log(
+        `       GET ${c.path}  ->  ${res.status}, ${res.body.length} bytes`
+      );
+      if (!ok) {
+        failures.push({
+          name: c.name,
+          path: c.path,
+          status: res.status,
+          preview: res.body.slice(0, 240).replace(/\s+/g, ' '),
+        });
+      }
+    }
+
+    console.log('='.repeat(72));
+    if (failures.length === 0) {
+      console.log('  RESULT: all checks passed — path traversal is mitigated.');
+    } else {
+      console.log(`  RESULT: ${failures.length} check(s) failed:`);
+      for (const f of failures) {
+        console.log(`    - ${f.name}`);
+        console.log(`        ${f.path}  ->  HTTP ${f.status}`);
+        console.log(`        body[0..240]: ${f.preview}`);
+      }
+    }
+    console.log('='.repeat(72));
+  } catch (err) {
+    console.error('test runner error:', err);
+    if (serverLog) {
+      console.error('--- server output ---');
+      console.error(serverLog);
+    }
+    failures.push({
+      name: 'runner',
+      path: '-',
+      status: 0,
+      preview: String(err),
+    });
+  } finally {
+    server.kill('SIGTERM');
+    await new Promise(resolve => {
+      server.once('exit', resolve);
+      setTimeout(resolve, 1000).unref?.();
+    });
+    await teardownStaticDir();
+  }
+
+  process.exit(failures.length === 0 ? 0 : 1);
+}
+
+main().catch(err => {
+  console.error('fatal:', err);
+  process.exit(2);
+});

--- a/server.mjs
+++ b/server.mjs
@@ -34,8 +34,7 @@ const MIME_TYPES = {
 };
 
 // Single merged directory: UI dist + docs copied into dist/docs/
-const STATIC_DIR = join(__dirname, 'apps', 'ui', 'dist');
-const STATIC_ROOT = resolve(STATIC_DIR);
+const STATIC_ROOT = resolve(__dirname, 'apps', 'ui', 'dist');
 
 // Boundary check used to mitigate CWE-22 path traversal.
 // The WHATWG URL parser does not normalize `..` segments when the slash is

--- a/server.mjs
+++ b/server.mjs
@@ -7,7 +7,7 @@
 
 import { createServer } from 'node:http';
 import { readFile, stat } from 'node:fs/promises';
-import { join, extname } from 'node:path';
+import { join, extname, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -35,6 +35,17 @@ const MIME_TYPES = {
 
 // Single merged directory: UI dist + docs copied into dist/docs/
 const STATIC_DIR = join(__dirname, 'apps', 'ui', 'dist');
+const STATIC_ROOT = resolve(STATIC_DIR);
+
+// Boundary check used to mitigate CWE-22 path traversal.
+// The WHATWG URL parser does not normalize `..` segments when the slash is
+// percent-encoded (e.g. `..%2f..%2f` or `%2e%2e%2f`), so once we run the
+// pathname through decodeURIComponent the `..` segments can survive. We
+// must therefore re-resolve the joined path and confirm it is still
+// confined to STATIC_ROOT before touching the filesystem.
+function isInsideStaticRoot(absPath) {
+  return absPath === STATIC_ROOT || absPath.startsWith(STATIC_ROOT + sep);
+}
 
 async function serveFile(res, filePath) {
   try {
@@ -70,7 +81,23 @@ async function exists(filePath) {
 const server = createServer(async (req, res) => {
   const url = new URL(req.url, `http://${req.headers.host}`);
   const pathname = decodeURIComponent(url.pathname);
-  const filePath = join(STATIC_DIR, pathname);
+
+  // Defense in depth: refuse decoded paths containing NUL bytes or
+  // backslashes. These never appear in legitimate static asset URLs and
+  // are common ingredients in path-confusion attacks.
+  if (pathname.includes('\0') || pathname.includes('\\')) {
+    res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Bad Request');
+    return;
+  }
+
+  // Resolve to an absolute, normalized path and confine to STATIC_ROOT.
+  const filePath = resolve(STATIC_ROOT, '.' + pathname);
+  if (!isInsideStaticRoot(filePath)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Forbidden');
+    return;
+  }
 
   // Try exact file
   if (await exists(filePath)) {
@@ -87,7 +114,7 @@ const server = createServer(async (req, res) => {
 
   // For /docs/* paths, serve the docs 404 page
   if (pathname.startsWith('/docs')) {
-    const docs404 = join(STATIC_DIR, 'docs', '404.html');
+    const docs404 = join(STATIC_ROOT, 'docs', '404.html');
     if (await exists(docs404)) {
       const data = await readFile(docs404, 'utf-8');
       res.writeHead(404, { 'Content-Type': 'text/html; charset=utf-8' });
@@ -97,7 +124,7 @@ const server = createServer(async (req, res) => {
   }
 
   // SPA fallback for UI routes
-  await serveFile(res, join(STATIC_DIR, 'index.html'));
+  await serveFile(res, join(STATIC_ROOT, 'index.html'));
 });
 
 server.listen(PORT, () => {


### PR DESCRIPTION
## Summary

This PR fixes a path traversal vulnerability ([CWE-22](https://cwe.mitre.org/data/definitions/22.html)) in `server.mjs`, the public-facing Node.js static server that ships AgentScript on Heroku (`Procfile: web: node server.mjs`). Without authentication, an attacker could read arbitrary files inside the dyno's working directory — including `package.json`, `Procfile`, `LICENSE.txt`, and any source under `/app/` — by issuing a single crafted request:

```
GET /%2e%2e%2f%2e%2e%2f%2e%2e%2fpackage.json
```

Vulnerability discovered, validated, and patched by [Rubber Duck](https://www.rubberduck.com).

## Root cause

`server.mjs` resolved request paths with:

```js
const url      = new URL(req.url, `http://${req.headers.host}`);
const pathname = decodeURIComponent(url.pathname);
const filePath = join(STATIC_DIR, pathname); // no containment check
```

The WHATWG URL parser only normalizes `..` segments when the separator is a **literal** `/`. When the slash itself is percent-encoded (`%2f`) — or both the dots and the slash are encoded (`%2e%2e%2f`) — the parser keeps the segment opaque, `decodeURIComponent` later restores the literal `../`, and `path.join` walks above `STATIC_DIR`. There was no post-join boundary check, no `realpath`, no allowlist.

## Fix

- **Re-resolve and confine.** After decoding, the request path is resolved against `STATIC_ROOT` and verified to stay inside it; otherwise the server returns `403 Forbidden`.
- **Defense in depth.** Decoded paths containing NUL bytes (`\0`) or backslashes (`\`) — never legitimate in static URLs, common in path-confusion payloads — are rejected with `400 Bad Request`.
- **No behavioral change** for legitimate requests: SPA fallback, `/docs/*` routing, and MIME handling are preserved.

## Regression coverage

A new self-contained regression suite (`scripts/test-path-traversal.mjs`) boots the **real `server.mjs`** in a child process, sets up a hermetic stub `apps/ui/dist/index.html` (with backup/restore so a developer's `pnpm build` output is never destroyed), and exercises:

- baseline — `GET /` serves the stub `index.html`
- traversal, half-encoded — `..%2f..%2f..%2f{package.json,Procfile,LICENSE.txt}`
- traversal, fully encoded — `%2e%2e%2f%2e%2e%2f%2e%2e%2f…`
- negative controls — literal `../../../` and `%2e%2e/…` (already normalized by the URL parser)

Exit code is `0` only if **every** traversal case is blocked AND the baseline is served — so any future regression to `server.mjs` fails CI loudly.

## CI

A new GitHub Actions job, `server-security-test`, runs the regression suite on every push and PR and is now a required dependency of `build`. Also exposed as `pnpm test:server-path-traversal` for local use.

## Test plan

- [x] `pnpm test:server-path-traversal` passes locally (7/7 cases, including baseline).
- [x] Reverting `server.mjs` to the vulnerable version makes the suite fail with `FAIL — VULNERABLE` on all four traversal payloads.
- [x] `pnpm test`, `pnpm lint`, `pnpm typecheck`, `pnpm build` unaffected.
- [x] Manual smoke: `node server.mjs`, hit `/`, `/docs/`, `/assets/...` — identical behavior to `main`.

## Severity & impact

| Field | Value |
|---|---|
| CWE | [CWE-22 — Path Traversal](https://cwe.mitre.org/data/definitions/22.html) |
| Auth required | None |
| Exposure | Public Heroku dyno (`Procfile: web: node server.mjs`) |
| Pre-fix behavior | Arbitrary file read inside `/app/` |
| Post-fix behavior | `403 Forbidden` outside `STATIC_ROOT` |

## Credits

Vulnerability **discovered, validated, and patched** by [Rubber Duck](https://www.rubberduck.com) — semantic code intelligence that ships exploits, fixes, and regression tests alongside findings. The full validation report (Rubberduck MCP `scan_bug_signals` F2 HIGH on `readFile` at L41 + L92, end-to-end taint trace, exploit confirmation) is available on request.
