### PR TITLE
Build and release vscode extension v2.4.0

### DIFF
--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -6,6 +6,76 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-5-1
+
+### Added
+
+- Support for `@VoiceCall` context variables for voice channel integrations.
+- Support for `@utils.end_session` as a callable tool to programmatically end agent sessions.
+- Enhanced code completion that works inside partially-typed `with` statements and uses indentation-based fallback for better accuracy.
+- Validation for `routes.when` expressions - now requires boolean-like expressions (comparisons, logical operators, or boolean literals).
+- New lint rule that flags spreading non-iterable literals (None, numbers, booleans, strings) which will fail at runtime.
+- Validation for duplicate `with` and `set` statements within the same scope.
+- Enhanced code snippets for collection blocks and enum types with example-based suggestions.
+
+### Changed
+
+- The `topic` block keyword now shows a deprecation warning suggesting to use `subagent` instead.
+- Connection `response_tools` renamed to `response_actions` throughout.
+- Connection instructions now use template-only syntax (`|` instead of `->`).
+- Renamed `action_definitions` to `actions` in AgentFabric dialect for consistency.
+- Removed the lint requirement that variables must be linked on connected agents.
+- Code completions for `reasoning.instructions` actions now correctly resolve action references.
+- LLM `kind` values now have canonical enum constraints for validation.
+
+### Fixed
+
+- Position range calculation for cursor-based operations now correctly handles boundary conditions.
+
+### Changed
+
+- Updated dependencies:
+  - @agentscript/lsp-server@2.2.25
+  - @agentscript/lsp@2.2.25
+  - @agentscript/agentforce@2.5.31
+
+## [2.2.4] - 2026-4-23
+
+### Added
+
+- Syntax support for connection inputs and structured response format definitions.
+- Validation for unbound connected subagent inputs.
+- Support for placeholder (stub) actions.
+- Commerce Cloud Shopper Agent custom subagent support.
+
+### Fixed
+
+- Syntax highlighting now works correctly with light themes and third-party color themes.
+- Special character escaping in string literals during compilation.
+
+### Changed
+
+- Removed `unused-variable` lint warnings (now shown as informational diagnostics).
+- Removed non-existent `@utils.supervise` from language completions.
+- Updated dependencies:
+  - @agentscript/agentforce@2.5.19
+  - @agentscript/lsp-server@2.2.14
+
+## [2.2.3] - 2026-4-14
+
+### Added
+
+- Syntax support for `on_init` and `on_exit` properties on custom subagents.
+- Syntax support for the spread operator (`*expr`) to unpack arrays in function calls and list literals. For example: `fn(*@variables.items)` or `[*@variables.existing, new_item]`.
+- Enhanced validation and code completion for custom subagent schemas.
+
+### Changed
+
+- Action parameter type mismatches now appear as warnings instead of errors, allowing for more flexible type handling.
+- Updated dependencies:
+  - @agentscript/agentforce@2.5.19
+  - @agentscript/lsp-server@2.2.14
+
 ## [2.2.2] - 2026-4-10
 
 ### Added

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "@agentscript/vscode",
   "displayName": "Agent Script",
   "description": "VS Code extension for Agent Script language support",
-  "version": "2.2.4",
+  "version": "2.4.0",
   "private": true,
   "publisher": "Salesforce",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Update VSCode extension from 2.2.4 to 2.4.0 with comprehensive changelog documenting all user-facing changes from the internal sync commit (794ca59).

## Changes
- Bump package version from 2.2.4 to 2.4.0
- Update CHANGELOG.md with detailed 2.4.0 release notes

## Major Features in 2.4.0
- **Deprecation**: `topic` block now shows deprecation warning (primary reason for minor version bump)
- Support for `@VoiceCall` context variables for voice channel integrations
- Support for `@utils.end_session` as a callable tool
- Enhanced code completion with indentation-based fallback for partially-typed statements
- New validation rules:
  - `routes.when` requires boolean-like expressions
  - Spreading non-iterable literals (None, numbers, booleans, strings) is flagged
  - Duplicate `with` and `set` statements are detected
- Connection syntax updates: `response_tools` → `response_actions`
- Connection instructions now use template-only syntax
- Enhanced code snippets for collection blocks and enums

## Testing
- ✅ Clean build from repository root completed successfully
- ✅ VSCode extension packaged successfully (agent-script-language-client-2.4.0.vsix)
- ✅ Extension installed locally for manual testing

## Checklist
- [x] Version bumped to 2.4.0
- [x] CHANGELOG.md updated with all user-facing changes
- [x] Clean build successful
- [x] Extension packages successfully

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>