### PR TITLE
fix: add C++20 flags to binding.gyp for Node.js 24 compatibility

### DIFF
--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -101,6 +101,41 @@ nvm use 18.20.8
 
 - **Pre-commit hooks** are configured via Husky and lint-staged. They run automatically on staged files when you commit.
 
+## Troubleshooting
+
+### Build fails on Node.js 24 with "C++20 or later required"
+
+Node.js 24 upgraded its V8 headers to require C++20. If you see errors like:
+
+```
+error: C++20 or later required.
+error: unknown type name 'concept'
+```
+
+This was caused by `binding.gyp` not specifying the C++ standard for the native tree-sitter binding. It is fixed in the current codebase. If you encounter it, make sure you are on the latest `main` branch:
+
+```bash
+git pull origin main
+pnpm install
+pnpm build
+```
+
+As a temporary workaround on older checkouts:
+
+```bash
+CXXFLAGS="-std=c++20" pnpm install
+```
+
+### `@agentscript/agentforce` not found on npm
+
+The package is published as part of the monorepo build. If you see "package not found" errors during install, run a full build first:
+
+```bash
+pnpm build
+```
+
+If you are trying to use the package as a consumer (outside this repo), check the [npm registry](https://www.npmjs.com/search?q=%40agentscript) for the latest published version — publishing cadence may lag behind `main`.
+
 ## Next Steps
 
 - [Quickstart](/getting-started/quickstart) -- Build the project and explore the structure.

--- a/packages/parser-tree-sitter/binding.gyp
+++ b/packages/parser-tree-sitter/binding.gyp
@@ -15,6 +15,15 @@
       "variables": {
         "has_scanner": "<!(node -p \"fs.existsSync('src/scanner.c')\")"
       },
+      "cflags_cc": ["-std=c++20"],
+      "xcode_settings": {
+        "OTHER_CPLUSPLUSFLAGS": ["-std=c++20", "-stdlib=libc++"],
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": {
+          "AdditionalOptions": ["/std:c++20"],
+        },
+      },
       "conditions": [
         ["has_scanner=='true'", {
           "sources+": ["src/scanner.c"],


### PR DESCRIPTION
## Summary

Fixes #7.

Node.js 24 upgraded its V8 headers to require C++20. The `binding.gyp` in `packages/parser-tree-sitter` only set `cflags_c` for the C parser but never set `cflags_cc` for `binding.cc`, causing a hard compile failure on Node 24:

\`\`\`
error: C++20 or later required.
error: unknown type name 'concept'
\`\`\`

## Changes

- **`packages/parser-tree-sitter/binding.gyp`**: Add C++20 compiler flags for all three platforms — Linux (`cflags_cc`), macOS (`xcode_settings`), Windows (`msvs_settings`)
- **`apps/docs/docs/getting-started/installation.md`**: Add a Troubleshooting section covering this error and the npm package visibility issue (#6)

The fix follows the same pattern used by `better-sqlite3` and other native Node addons that require C++20.