### PR TITLE
docs: add conditionals section to syntax reference

### DIFF
--- a/apps/docs/docs/language/syntax.mdx
+++ b/apps/docs/docs/language/syntax.mdx
@@ -149,6 +149,24 @@ variables:
 - `2025-09-04`, `2025-09-04T12:01Z` -- Datetime literals in ISO 8601 format. Supported formats include date only (`YYYY-MM-DD`), date with time (`YYYY-MM-DDThh:mm`), and date with seconds and timezone (`YYYY-MM-DDThh:mm:ssZ`).
 - `empty` -- Explicitly marks a block as having no content (e.g., `connection slack: empty`)
 
+## Conditionals
+
+Inside a procedure, `if`, `elif`, and `else` control which statements execute based on runtime values:
+
+```agentscript
+instructions: ->
+    if @variables.loyalty_tier == "Premium":
+        | You are eligible for a free return.
+    elif @variables.return_eligible == True:
+        | Processing your return request.
+    else:
+        | Please contact support for assistance.
+```
+
+- `elif` and `else` are optional.
+- Multiple `elif` branches are supported.
+- The body of each branch is indented one level and can contain any procedure statements — template lines, `set`, `run`, or `transition`.
+
 ## Line Continuation
 
 Use `\` at the end of a line to continue a statement on the next line:


### PR DESCRIPTION
## Summary

The `syntax.mdx` reference page documents key-value pairs, templates, procedures, variables, and keywords — but has no section on conditional logic (`if`/`elif`/`else`), even though conditionals are one of the most commonly used language features.

This PR adds a dedicated **Conditionals** section to the syntax reference with a clear example and a short explanation of each clause.

## Changes

- **`apps/docs/docs/language/syntax.mdx`**: Add `## Conditionals` section covering `if`, `elif`, and `else` with a working example