### PR TITLE
fix tree-sitter install on node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,36 @@ jobs:
         run: pnpm --filter @agentscript/docs validate-code-blocks
         continue-on-error: true
 
+  node24-install:
+    name: Node 24 Install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint-and-typecheck, test, server-security-test, validate-docs]
+    needs:
+      [
+        lint-and-typecheck,
+        test,
+        server-security-test,
+        validate-docs,
+        node24-install,
+      ]
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -179,4 +205,3 @@ jobs:
 
       - name: Build packages
         run: pnpm build
-

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
   "pnpm": {
     "overrides": {
       "vite": "^7.3.2"
+    },
+    "patchedDependencies": {
+      "tree-sitter@0.25.0": "patches/tree-sitter@0.25.0.patch"
     }
   },
   "packageManager": "pnpm@10.28.0",

--- a/patches/tree-sitter@0.25.0.patch
+++ b/patches/tree-sitter@0.25.0.patch
@@ -1,0 +1,29 @@
+diff --git a/binding.gyp b/binding.gyp
+index bb40aa7e8d41644ba690761e9064fc1d0f2dcd6b..1e1641b2e3d6733642ea0ff06cd88b3b3023fd6c 100644
+--- a/binding.gyp
++++ b/binding.gyp
+@@ -25,13 +25,13 @@
+         "NAPI_VERSION=<(napi_build_version)",
+       ],
+       "cflags_cc": [
+-        "-std=c++17"
++        "-std=c++20"
+       ],
+       "conditions": [
+         ["OS=='mac'", {
+           "xcode_settings": {
+             "GCC_SYMBOLS_PRIVATE_EXTERN": "YES", # -fvisibility=hidden
+-            "CLANG_CXX_LANGUAGE_STANDARD": "c++17",
++            "CLANG_CXX_LANGUAGE_STANDARD": "c++20",
+             "MACOSX_DEPLOYMENT_TARGET": "10.9",
+           },
+         }],
+@@ -39,7 +39,7 @@
+           "msvs_settings": {
+             "VCCLCompilerTool": {
+               "AdditionalOptions": [
+-                "/std:c++17",
++                "/std:c++20",
+               ],
+               "RuntimeLibrary": 0,
+             },

--- a/patches/tree-sitter@0.25.0.patch
+++ b/patches/tree-sitter@0.25.0.patch
@@ -1,29 +1,47 @@
 diff --git a/binding.gyp b/binding.gyp
-index bb40aa7e8d41644ba690761e9064fc1d0f2dcd6b..1e1641b2e3d6733642ea0ff06cd88b3b3023fd6c 100644
+index bb40aa7e8d41644ba690761e9064fc1d0f2dcd6b..724b177f43bf6ed7cf60add3f23317be2018f6ff 100644
 --- a/binding.gyp
 +++ b/binding.gyp
-@@ -25,13 +25,13 @@
+@@ -24,14 +24,11 @@
+       "defines": [
          "NAPI_VERSION=<(napi_build_version)",
        ],
-       "cflags_cc": [
+-      "cflags_cc": [
 -        "-std=c++17"
-+        "-std=c++20"
-       ],
+-      ],
        "conditions": [
          ["OS=='mac'", {
            "xcode_settings": {
              "GCC_SYMBOLS_PRIVATE_EXTERN": "YES", # -fvisibility=hidden
 -            "CLANG_CXX_LANGUAGE_STANDARD": "c++17",
-+            "CLANG_CXX_LANGUAGE_STANDARD": "c++20",
++            "CLANG_CXX_LANGUAGE_STANDARD": "<(cxxstd)",
              "MACOSX_DEPLOYMENT_TARGET": "10.9",
            },
          }],
-@@ -39,7 +39,7 @@
+@@ -39,15 +36,17 @@
            "msvs_settings": {
              "VCCLCompilerTool": {
                "AdditionalOptions": [
 -                "/std:c++17",
-+                "/std:c++20",
++                "/std:<(cxxstd)",
                ],
                "RuntimeLibrary": 0,
              },
+           },
+         }],
+         ["OS == 'linux'", {
+           "cflags_cc": [
+-            "-Wno-cast-function-type"
++            "-std=<(cxxstd)",
++            "-fvisibility=hidden",
++            "-Wno-cast-function-type",
+           ]
+         }],
+       ]
+@@ -75,5 +74,6 @@
+     "openssl_fips": "",
+     "v8_enable_pointer_compression%": 0,
+     "v8_enable_31bit_smis_on_64bit_arch%": 0,
++    "cxxstd%": "<!(node -p \"parseInt(process.env.npm_config_target ?? process.versions.node) < 22 ? 'c++17' : 'c++20'\")",
+   }
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   vite: ^7.3.2
 
+patchedDependencies:
+  tree-sitter@0.25.0:
+    hash: 581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb
+    path: patches/tree-sitter@0.25.0.patch
+
 importers:
 
   .:
@@ -358,7 +363,7 @@ importers:
         version: link:../../packages/parser
       tree-sitter:
         specifier: ^0.25.0
-        version: 0.25.0
+        version: 0.25.0(patch_hash=581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -604,7 +609,7 @@ importers:
         version: link:../types
       tree-sitter:
         specifier: ^0.25.0
-        version: 0.25.0
+        version: 0.25.0(patch_hash=581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb)
       web-tree-sitter:
         specifier: '>=0.22.0'
         version: 0.25.10
@@ -630,7 +635,7 @@ importers:
         version: 6.2.1
       tree-sitter:
         specifier: ^0.25.0
-        version: 0.25.0
+        version: 0.25.0(patch_hash=581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb)
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -645,7 +650,7 @@ importers:
         version: 4.8.4
       tree-sitter:
         specifier: ^0.25.0
-        version: 0.25.0
+        version: 0.25.0(patch_hash=581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb)
     devDependencies:
       node-gyp:
         specifier: ^11.5.0
@@ -20197,7 +20202,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  tree-sitter@0.25.0:
+  tree-sitter@0.25.0(patch_hash=581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb):
     dependencies:
       node-addon-api: 8.5.0
       node-gyp-build: 4.8.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   tree-sitter@0.25.0:
-    hash: 581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb
+    hash: 1126ded4a25fbe2a39815134004bbdcca908eef4a66a01e2932386126ec59aac
     path: patches/tree-sitter@0.25.0.patch
 
 importers:
@@ -363,7 +363,7 @@ importers:
         version: link:../../packages/parser
       tree-sitter:
         specifier: ^0.25.0
-        version: 0.25.0(patch_hash=581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb)
+        version: 0.25.0(patch_hash=1126ded4a25fbe2a39815134004bbdcca908eef4a66a01e2932386126ec59aac)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -609,7 +609,7 @@ importers:
         version: link:../types
       tree-sitter:
         specifier: ^0.25.0
-        version: 0.25.0(patch_hash=581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb)
+        version: 0.25.0(patch_hash=1126ded4a25fbe2a39815134004bbdcca908eef4a66a01e2932386126ec59aac)
       web-tree-sitter:
         specifier: '>=0.22.0'
         version: 0.25.10
@@ -635,7 +635,7 @@ importers:
         version: 6.2.1
       tree-sitter:
         specifier: ^0.25.0
-        version: 0.25.0(patch_hash=581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb)
+        version: 0.25.0(patch_hash=1126ded4a25fbe2a39815134004bbdcca908eef4a66a01e2932386126ec59aac)
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -650,7 +650,7 @@ importers:
         version: 4.8.4
       tree-sitter:
         specifier: ^0.25.0
-        version: 0.25.0(patch_hash=581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb)
+        version: 0.25.0(patch_hash=1126ded4a25fbe2a39815134004bbdcca908eef4a66a01e2932386126ec59aac)
     devDependencies:
       node-gyp:
         specifier: ^11.5.0
@@ -20202,7 +20202,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  tree-sitter@0.25.0(patch_hash=581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb):
+  tree-sitter@0.25.0(patch_hash=1126ded4a25fbe2a39815134004bbdcca908eef4a66a01e2932386126ec59aac):
     dependencies:
       node-addon-api: 8.5.0
       node-gyp-build: 4.8.4


### PR DESCRIPTION
## What

- Adds a pnpm patch for `tree-sitter@0.25.0` so its native binding builds with C++20 instead of C++17.
- Records the patched dependency in the lockfile.
- Adds a Node 24 install CI job to cover the reported install regression.

## Why

Fixes #7.

Node 24 V8 headers require C++20, but `tree-sitter@0.25.0` forces C++17 in `binding.gyp`. That makes `pnpm install` fail when the native binding compiles under Node 24.

## How

The pnpm patch updates the upstream package build flags for Unix, macOS/Xcode, and Windows/MSVC to C++20. The new CI job runs `pnpm install --frozen-lockfile` on Node 24 so the install path is checked directly.

## Test Plan

- [x] `corepack pnpm install --frozen-lockfile` on Node v24.10.0 without `CXXFLAGS`
- [x] `corepack pnpm rebuild tree-sitter` on Node v24.10.0 without `CXXFLAGS`
- [x] `node --test packages/parser-tree-sitter/bindings/node/*_test.js`
- [x] `corepack pnpm --filter @agentscript/parser test`
- [x] `corepack pnpm exec prettier --check .github/workflows/ci.yml package.json pnpm-lock.yaml`
- [ ] `corepack pnpm --filter @agentscript/parser-tree-sitter test` (local machine is missing the external `tree-sitter` CLI; its Node binding subtest passed)

## Checklist

- [x] My code follows the project's coding style
- [x] I have reviewed my own diff
- [x] I have added/updated documentation as needed
- [x] This change does not introduce new warnings