### PR TITLE
fix(lint): update import path after lint-engine rename

### DIFF
--- a/packages/language/src/lint/unsupported-conditionals.test.ts
+++ b/packages/language/src/lint/unsupported-conditionals.test.ts
@@ -10,7 +10,7 @@ import { parse } from '@agentscript/parser';
 import { Dialect } from '../core/dialect.js';
 import { NamedBlock, NamedCollectionBlock } from '../core/block.js';
 import { StringValue, ProcedureValue } from '../core/primitives.js';
-import { LintEngine } from '../core/analysis/lint.js';
+import { LintEngine } from '../core/analysis/lint-engine.js';
 import { createSchemaContext } from '../core/analysis/scope.js';
 import { unsupportedConditionalsPass } from './unsupported-conditionals.js';
 

--- a/packages/language/src/lint/unsupported-conditionals.ts
+++ b/packages/language/src/lint/unsupported-conditionals.ts
@@ -12,7 +12,7 @@ import {
   storeKey,
   type LintPass,
   type PassStore,
-} from '../core/analysis/lint.js';
+} from '../core/analysis/lint-engine.js';
 import { lintDiagnostic } from './lint-utils.js';
 import {
   type Statement,


### PR DESCRIPTION
## Summary
Two files in the unsupported-conditionals lint pass were importing `LintEngine` from `../core/analysis/lint.js`, but that module was renamed to `lint-engine.js` upstream. The broken import caused CI typecheck failures with cascading errors:

- `TS2307: Cannot find module '../core/analysis/lint.js'` (the actual cause)
- `TS7006: Parameter 'd' implicitly has an 'any' type` (cascade — once `LintEngine` was unresolved, `engine.run()` returned `any` and filter parameter inference collapsed)

This PR updates both import paths to the new file name.

## Test plan
- [x] `pnpm --filter @agentscript/language typecheck` — passes
- [x] `pnpm --filter @agentscript/language test` — all 166 tests pass