### PR TITLE
docs(readme): correct npm install scope to @sf-agentscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,14 @@ Opens the AgentScript playground at `http://localhost:27002`.
 
 ### Use as a Library
 
+> Packages are published to npm under the `@sf-agentscript/*` scope. The `@agentscript/*` names used elsewhere in this repo are the internal monorepo names — see [`scripts/publish.mjs`](scripts/publish.mjs).
+
 ```bash
-pnpm add @agentscript/agentforce
+pnpm add @sf-agentscript/agentforce
 ```
 
 ```typescript
-import { parse } from '@agentscript/agentforce';
+import { parse } from '@sf-agentscript/agentforce';
 
 const doc = parse(`
 system:


### PR DESCRIPTION
## What

Updates the README Quick Start to install/import the npm-published package name (`@sf-agentscript/agentforce`) instead of the internal monorepo name (`@agentscript/agentforce`), and adds a one-line note explaining the scope distinction.

## Why

Fixes #6. Users following the README run `pnpm add @agentscript/agentforce` and get a 404 from npm — the package isn't published under that name. `scripts/publish.mjs` (lines 14–15) rewrites `@agentscript/*` → `@sf-agentscript/*` at publish time, so the source name is never on npm. PR #23 added a troubleshooting note about this symptom in `installation.md`; this PR fixes the root cause in the README.

Note: while verifying the fix end-to-end I also discovered that the published package's compiled `dist/` files still reference `@agentscript/*` imports, causing `ERR_MODULE_NOT_FOUND` on import even after installing the correct package. That's a separate publish-script bug and will be filed in its own issue.

## How

Two-line edit in `README.md` plus a `>` blockquote pointing readers at `scripts/publish.mjs`. No code, tooling, or other doc changes.

## Test Plan

Docs-only README change — no executable code modified.

- [x] `pnpm lint` passes locally (0 errors; the 12 warnings in `apps/ui/` are pre-existing react-refresh warnings unrelated to this change)
- [x] `pnpm typecheck` verified by CI (local tree-sitter CLI not set up; the README change cannot affect typecheck)
- [ ] New/updated tests cover the change — N/A (docs-only)

## Checklist

- [x] My code follows the project's coding style
- [x] I have reviewed my own diff
- [x] I have added/updated documentation as needed
- [x] This change does not introduce new warnings
