### PR TITLE
docs(readme): document tree-sitter CLI prereq and recommend mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,19 @@ In this sense Agent Script follows the same pattern as other industry-standard d
 
 ### Prerequisites
 
-Node.js >= 20 and pnpm >= 8
+The simplest setup is to use [mise](https://mise.jdx.dev/), which installs the toolchain versions pinned in [`mise.toml`](mise.toml) (Node.js and the `tree-sitter` CLI):
+
+```bash
+mise install
+```
+
+To set up manually instead:
+
+- **Node.js 22** (minimum `>=18`)
+- **pnpm 10** — run `corepack enable pnpm` once; pnpm will resolve to the version pinned by `packageManager` in `package.json`
+- **`tree-sitter` CLI 0.25.x** on your `$PATH` — required by `pnpm build` to generate the parser for `packages/parser-tree-sitter`. Install via `mise install`, or download a 0.25.x binary from [tree-sitter releases](https://github.com/tree-sitter/tree-sitter/releases).
+
+**macOS note:** `brew install tree-sitter` installs only the C library, not the CLI. For the CLI on macOS, use `mise install` (recommended; matches the pinned 0.25.x line) or `brew install tree-sitter-cli` (currently ships 0.26.x).
 
 ### Installation
 


### PR DESCRIPTION
## What

Expands the README **Prerequisites** section to document the `tree-sitter` CLI as a build prerequisite (previously omitted) and recommends `mise install` as the simplest setup path since [`mise.toml`](mise.toml) already pins both Node.js and tree-sitter.

## Why

Addresses #33 Part B (the undocumented CLI prerequisite). The previous Prerequisites section listed only "Node.js >= 20 and pnpm >= 8", so new contributors run `pnpm build` and hit `sh: tree-sitter: command not found` with no guidance from the README. The CLI is invoked by `packages/parser-tree-sitter`'s `generate`, `prebuild`, `build:wasm`, `start`, `test`, and `parse` scripts — so this affects anyone doing a from-scratch `pnpm install && pnpm build`.

Part A of #33 (Node 26 compatibility) is being addressed in #23 and #27.

## How

Docs-only change to the Prerequisites section of `README.md`:

- Leads with `mise install` (respects the pinned 0.25.x line in `mise.toml`)
- Provides a manual-install fallback explicitly listing Node 22, pnpm 10, and `tree-sitter` CLI 0.25.x
- Calls out the macOS Homebrew gotcha: `brew install tree-sitter` ships only the C library; the CLI is a separate `tree-sitter-cli` formula (and currently ships 0.26.x, a minor mismatch with the pinned 0.25.x line — `mise install` is the recommended way to get the right version)

## Alternatives considered

I initially considered an auto-install fix — adding `tree-sitter-cli` as a `devDependency` of `packages/parser-tree-sitter`. The npm package does install a working binary in ~2 seconds. I ruled it out because:

- pnpm 10's default policy blocks install scripts from new dependencies, so it would also require allowlisting `tree-sitter-cli` via `pnpm.onlyBuiltDependencies` in the root `package.json`.
- The repo already lives with this default policy — `esbuild`, `core-js`, `keytar`, and `@vscode/vsce-sign` all show up in the "Ignored build scripts" warning today, suggesting an intentional security stance.
- Allowlisting an install script is a policy decision worth its own discussion. Docs-first feels like the lower-risk path for this specific issue.

If maintainers prefer the auto-install approach, happy to follow up with a second PR.

## Test Plan

Docs-only change to `README.md`.

- [x] `pnpm lint` passes locally (0 errors; the 12 warnings in `apps/ui/` are pre-existing react-refresh warnings, unrelated)
- [x] `pnpm typecheck` verified by CI (a docs-only change cannot affect typecheck)
- [ ] New/updated tests cover the change — N/A (docs-only)

Manually verified that:

- The recommended `mise install` flow resolves `mise.toml`'s `node = '22'` and `tree-sitter = "0.25"` pins correctly
- The corepack/pnpm hint matches the `packageManager: "pnpm@10.28.0"` pin in root `package.json`
- The Homebrew gotcha is accurate: `brew info tree-sitter` shows "Incremental parsing library"; `brew info tree-sitter-cli` shows "Parser generator tool" — confirming the formula split

## Checklist

- [x] My code follows the project's coding style
- [x] I have reviewed my own diff
- [x] I have added/updated documentation as needed
- [x] This change does not introduce new warnings
