### PR TITLE
lint error on complex_data_type field for primitive type

### DIFF
--- a/dialect/agentforce/src/lint/passes/complex-data-type.ts
+++ b/dialect/agentforce/src/lint/passes/complex-data-type.ts
@@ -6,13 +6,16 @@
  */
 
 /**
- * Complex data type warning rule for Agentforce.
+ * Complex data type rule for Agentforce.
  *
- * Warns when object-type action inputs/outputs lack schema information:
- * - Inputs: should have complex_data_type_name or schema
- * - Outputs: should have complex_data_type_name
+ * Only `object` and `list[object]` declarations support a `complex_data_type_name`.
  *
- * Diagnostic: object-type-missing-schema
+ * - When a whitelisted type (`object` / `list[object]`) lacks schema info:
+ *   - Inputs: should have `complex_data_type_name` or `schema` (warning)
+ *   - Outputs: should have `complex_data_type_name` (warning)
+ * - When a non-whitelisted (primitive) type has `complex_data_type_name`: error.
+ *
+ * Diagnostics: object-type-missing-schema, complex-data-type-on-primitive
  */
 
 import type { AstNodeLike, AstRoot, NamedMap } from '@agentscript/language';
@@ -37,9 +40,14 @@ function getTypeText(decl: Record<string, unknown>): string | null {
   return cst?.node?.text?.trim() ?? null;
 }
 
-/** Check if a type string represents an object type. */
-function isObjectType(typeText: string): boolean {
-  return typeText === 'object' || typeText === 'list[object]';
+/**
+ * These required complex data types creates a warning without `complex_data_type_name` field.
+ * Anything outside this set is treated as a primitive and does not need a `complex_data_type_name`.
+ */
+const REQURIED_COMPLEX_DATA_TYPE = new Set<string>(['object', 'list[object]']);
+
+function isComplexType(typeText: string): boolean {
+  return REQURIED_COMPLEX_DATA_TYPE.has(typeText);
 }
 
 /** Check if a field has a non-empty string value. */
@@ -86,60 +94,66 @@ class ComplexDataTypePass implements LintPass {
           if (!actBlock || typeof actBlock !== 'object') continue;
           const act = actBlock as Record<string, unknown>;
 
-          this.checkInputs(act.inputs, actionName);
-          this.checkOutputs(act.outputs, actionName);
+          this.checkDecls(act.inputs, actionName, 'input');
+          this.checkDecls(act.outputs, actionName, 'output');
         }
       }
     }
   }
 
-  private checkInputs(inputs: unknown, actionName: string): void {
-    if (!inputs || !isNamedMap(inputs)) return;
+  private checkDecls(
+    decls: unknown,
+    actionName: string,
+    kind: 'input' | 'output'
+  ): void {
+    if (!decls || !isNamedMap(decls)) return;
 
-    for (const [paramName, decl] of inputs as NamedMap<unknown>) {
+    for (const [paramName, decl] of decls as NamedMap<unknown>) {
       if (!decl || typeof decl !== 'object') continue;
       const obj = decl as AstNodeLike;
       const typeText = getTypeText(obj as Record<string, unknown>);
-      if (!typeText || !isObjectType(typeText)) continue;
+      if (!typeText) continue;
 
       const props = (obj as Record<string, unknown>).properties as
         | Record<string, unknown>
         | undefined;
-      if (
-        !hasStringField(props, 'complex_data_type_name') &&
-        !hasStringField(props, 'schema')
-      ) {
-        attachDiagnostic(
-          obj,
-          lintDiagnostic(
-            getDeclRange(obj),
-            `Action input '${paramName}' in '${actionName}' has type '${typeText}' but lacks 'complex_data_type_name' or 'schema'. Consider specifying the object schema for better type validation.`,
-            DiagnosticSeverity.Warning,
-            'object-type-missing-schema'
-          )
-        );
+      const hasComplexDataTypeField = hasStringField(
+        props,
+        'complex_data_type_name'
+      );
+
+      if (!isComplexType(typeText)) {
+        // Primitive types must NOT declare complex_data_type_name.
+        if (hasComplexDataTypeField) {
+          attachDiagnostic(
+            obj,
+            lintDiagnostic(
+              getDeclRange(obj),
+              `Action ${kind} '${paramName}' in '${actionName}' has primitive type '${typeText}' and must not specify 'complex_data_type_name'. Only 'object' and 'list[object]' types support 'complex_data_type_name'.`,
+              DiagnosticSeverity.Error,
+              'complex-data-type-on-primitive'
+            )
+          );
+        }
+        continue;
       }
-    }
-  }
 
-  private checkOutputs(outputs: unknown, actionName: string): void {
-    if (!outputs || !isNamedMap(outputs)) return;
-
-    for (const [outputName, decl] of outputs as NamedMap<unknown>) {
-      if (!decl || typeof decl !== 'object') continue;
-      const obj = decl as AstNodeLike;
-      const typeText = getTypeText(obj as Record<string, unknown>);
-      if (!typeText || !isObjectType(typeText)) continue;
-
-      const props = (obj as Record<string, unknown>).properties as
-        | Record<string, unknown>
-        | undefined;
-      if (!hasStringField(props, 'complex_data_type_name')) {
+      // Complex types should declare schema info.
+      // Inputs may use `schema` as an alternative to `complex_data_type_name`.
+      const hasSchema =
+        hasComplexDataTypeField ||
+        (kind === 'input' && hasStringField(props, 'schema'));
+      console.log('Schema: ', hasSchema);
+      if (!hasSchema) {
+        const required =
+          kind === 'input'
+            ? `'complex_data_type_name' or 'schema'`
+            : `'complex_data_type_name'`;
         attachDiagnostic(
           obj,
           lintDiagnostic(
             getDeclRange(obj),
-            `Action output '${outputName}' in '${actionName}' has type '${typeText}' but lacks 'complex_data_type_name'. Consider specifying the object schema for better type validation.`,
+            `Action ${kind} '${paramName}' in '${actionName}' has type '${typeText}' but lacks ${required}. Consider specifying the object schema for better type validation.`,
             DiagnosticSeverity.Warning,
             'object-type-missing-schema'
           )

--- a/dialect/agentforce/src/lint/passes/complex-data-type.ts
+++ b/dialect/agentforce/src/lint/passes/complex-data-type.ts
@@ -129,8 +129,8 @@ class ComplexDataTypePass implements LintPass {
             obj,
             lintDiagnostic(
               getDeclRange(obj),
-              `Action ${kind} '${paramName}' in '${actionName}' has primitive type '${typeText}' and must not specify 'complex_data_type_name'. Only 'object' and 'list[object]' types support 'complex_data_type_name'.`,
-              DiagnosticSeverity.Error,
+              `Action ${kind} '${paramName}' in '${actionName}' has primitive type '${typeText}' and does not require 'complex_data_type_name'. Only 'object' and 'list[object]' types require 'complex_data_type_name'.`,
+              DiagnosticSeverity.Warning,
               'complex-data-type-on-primitive'
             )
           );

--- a/dialect/agentforce/src/tests/lint.test.ts
+++ b/dialect/agentforce/src/tests/lint.test.ts
@@ -2344,3 +2344,169 @@ subagent Order_Management:
   );
   expect(warnings.length).toBeGreaterThan(0);
 });
+
+describe('complex data type rule', () => {
+  const wrap = (inputs: string, outputs: string): string => `
+subagent S:
+  description: "S"
+  actions:
+    A:
+      description: "A"
+      inputs:
+${inputs}
+      outputs:
+${outputs}
+  reasoning:
+    instructions: ->
+      |Do it
+`;
+
+  it('errors when a primitive input has complex_data_type_name', () => {
+    const diagnostics = runSecurityLint(
+      wrap(
+        `        amount: number\n          complex_data_type_name: "lightning__objectType"\n`,
+        `        ok: object\n          complex_data_type_name: "lightning__objectType"\n`
+      )
+    );
+    const errors = diagnostics.filter(
+      d => d.code === 'complex-data-type-on-primitive'
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].severity).toBe(DiagnosticSeverity.Error);
+    expect(errors[0].message).toContain("'amount'");
+    expect(errors[0].message).toContain("'A'");
+    expect(errors[0].message).toContain("'number'");
+  });
+
+  it('does not flag primitive inputs without complex_data_type_name', () => {
+    const diagnostics = runSecurityLint(
+      wrap(
+        `        amount: number\n          description: "an amount"\n`,
+        `        ok: object\n          complex_data_type_name: "lightning__objectType"\n`
+      )
+    );
+    expect(
+      diagnostics.filter(d => d.code === 'complex-data-type-on-primitive')
+    ).toHaveLength(0);
+  });
+
+  it('errors when a primitive output has complex_data_type_name', () => {
+    const diagnostics = runSecurityLint(
+      wrap(
+        `        in_ok: object\n          complex_data_type_name: "lightning__objectType"\n`,
+        `        message: string\n          complex_data_type_name: "lightning__objectType"\n`
+      )
+    );
+    const errors = diagnostics.filter(
+      d => d.code === 'complex-data-type-on-primitive'
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("'message'");
+    expect(errors[0].message).toContain("'string'");
+  });
+
+  it.each([
+    ['boolean'],
+    ['integer'],
+    ['id'],
+    ['date'],
+    ['datetime'],
+    ['time'],
+    ['timestamp'],
+    ['currency'],
+    ['long'],
+  ])('errors when primitive type %s has complex_data_type_name', primitive => {
+    const diagnostics = runSecurityLint(
+      wrap(
+        `        v: ${primitive}\n          complex_data_type_name: "lightning__objectType"\n`,
+        `        ok: object\n          complex_data_type_name: "lightning__objectType"\n`
+      )
+    );
+    const errors = diagnostics.filter(
+      d => d.code === 'complex-data-type-on-primitive'
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain(`'${primitive}'`);
+  });
+
+  it('does not flag object input with complex_data_type_name', () => {
+    const diagnostics = runSecurityLint(
+      wrap(
+        `        order: object\n          complex_data_type_name: "OrderRecord"\n`,
+        `        ok: object\n          complex_data_type_name: "lightning__objectType"\n`
+      )
+    );
+    expect(
+      diagnostics.filter(
+        d =>
+          d.code === 'complex-data-type-on-primitive' ||
+          d.code === 'object-type-missing-schema'
+      )
+    ).toHaveLength(0);
+  });
+
+  it('does not flag object input that uses schema:', () => {
+    const diagnostics = runSecurityLint(
+      wrap(
+        `        order: object\n          schema: "schema://order_schema"\n`,
+        `        ok: object\n          complex_data_type_name: "lightning__objectType"\n`
+      )
+    );
+    expect(
+      diagnostics.filter(
+        d =>
+          d.code === 'complex-data-type-on-primitive' ||
+          d.code === 'object-type-missing-schema'
+      )
+    ).toHaveLength(0);
+  });
+
+  it('does not flag list[object] output with complex_data_type_name', () => {
+    const diagnostics = runSecurityLint(
+      wrap(
+        `        ok: object\n          complex_data_type_name: "lightning__objectType"\n`,
+        `        items: list[object]\n          complex_data_type_name: "OrderRecord"\n`
+      )
+    );
+    expect(
+      diagnostics.filter(
+        d =>
+          d.code === 'complex-data-type-on-primitive' ||
+          d.code === 'object-type-missing-schema'
+      )
+    ).toHaveLength(0);
+  });
+
+  it('errors on list[string] input with complex_data_type_name', () => {
+    const diagnostics = runSecurityLint(
+      wrap(
+        `        tags: list[string]\n          complex_data_type_name: "lightning__objectType"\n`,
+        `        ok: object\n          complex_data_type_name: "lightning__objectType"\n`
+      )
+    );
+    const errors = diagnostics.filter(
+      d => d.code === 'complex-data-type-on-primitive'
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("'list[string]'");
+  });
+
+  it('reports both error and warning for mixed declarations', () => {
+    const diagnostics = runSecurityLint(
+      wrap(
+        `        amount: number\n          complex_data_type_name: "lightning__objectType"\n`,
+        `        result: object\n          description: "bare object output"\n`
+      )
+    );
+    const errors = diagnostics.filter(
+      d => d.code === 'complex-data-type-on-primitive'
+    );
+    const warnings = diagnostics.filter(
+      d => d.code === 'object-type-missing-schema'
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("'amount'");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("'result'");
+  });
+});

--- a/dialect/agentforce/src/tests/lint.test.ts
+++ b/dialect/agentforce/src/tests/lint.test.ts
@@ -2361,21 +2361,21 @@ ${outputs}
       |Do it
 `;
 
-  it('errors when a primitive input has complex_data_type_name', () => {
+  it('warns when a primitive input has complex_data_type_name', () => {
     const diagnostics = runSecurityLint(
       wrap(
         `        amount: number\n          complex_data_type_name: "lightning__objectType"\n`,
         `        ok: object\n          complex_data_type_name: "lightning__objectType"\n`
       )
     );
-    const errors = diagnostics.filter(
+    const warnings = diagnostics.filter(
       d => d.code === 'complex-data-type-on-primitive'
     );
-    expect(errors).toHaveLength(1);
-    expect(errors[0].severity).toBe(DiagnosticSeverity.Error);
-    expect(errors[0].message).toContain("'amount'");
-    expect(errors[0].message).toContain("'A'");
-    expect(errors[0].message).toContain("'number'");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].severity).toBe(DiagnosticSeverity.Warning);
+    expect(warnings[0].message).toContain("'amount'");
+    expect(warnings[0].message).toContain("'A'");
+    expect(warnings[0].message).toContain("'number'");
   });
 
   it('does not flag primitive inputs without complex_data_type_name', () => {
@@ -2390,19 +2390,20 @@ ${outputs}
     ).toHaveLength(0);
   });
 
-  it('errors when a primitive output has complex_data_type_name', () => {
+  it('warns when a primitive output has complex_data_type_name', () => {
     const diagnostics = runSecurityLint(
       wrap(
         `        in_ok: object\n          complex_data_type_name: "lightning__objectType"\n`,
         `        message: string\n          complex_data_type_name: "lightning__objectType"\n`
       )
     );
-    const errors = diagnostics.filter(
+    const warnings = diagnostics.filter(
       d => d.code === 'complex-data-type-on-primitive'
     );
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain("'message'");
-    expect(errors[0].message).toContain("'string'");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].severity).toBe(DiagnosticSeverity.Warning);
+    expect(warnings[0].message).toContain("'message'");
+    expect(warnings[0].message).toContain("'string'");
   });
 
   it.each([
@@ -2415,18 +2416,19 @@ ${outputs}
     ['timestamp'],
     ['currency'],
     ['long'],
-  ])('errors when primitive type %s has complex_data_type_name', primitive => {
+  ])('warns when primitive type %s has complex_data_type_name', primitive => {
     const diagnostics = runSecurityLint(
       wrap(
         `        v: ${primitive}\n          complex_data_type_name: "lightning__objectType"\n`,
         `        ok: object\n          complex_data_type_name: "lightning__objectType"\n`
       )
     );
-    const errors = diagnostics.filter(
+    const warnings = diagnostics.filter(
       d => d.code === 'complex-data-type-on-primitive'
     );
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain(`'${primitive}'`);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].severity).toBe(DiagnosticSeverity.Warning);
+    expect(warnings[0].message).toContain(`'${primitive}'`);
   });
 
   it('does not flag object input with complex_data_type_name', () => {
@@ -2477,36 +2479,38 @@ ${outputs}
     ).toHaveLength(0);
   });
 
-  it('errors on list[string] input with complex_data_type_name', () => {
+  it('warns on list[string] input with complex_data_type_name', () => {
     const diagnostics = runSecurityLint(
       wrap(
         `        tags: list[string]\n          complex_data_type_name: "lightning__objectType"\n`,
         `        ok: object\n          complex_data_type_name: "lightning__objectType"\n`
       )
     );
-    const errors = diagnostics.filter(
+    const warnings = diagnostics.filter(
       d => d.code === 'complex-data-type-on-primitive'
     );
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain("'list[string]'");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].severity).toBe(DiagnosticSeverity.Warning);
+    expect(warnings[0].message).toContain("'list[string]'");
   });
 
-  it('reports both error and warning for mixed declarations', () => {
+  it('reports both warnings for mixed declarations', () => {
     const diagnostics = runSecurityLint(
       wrap(
         `        amount: number\n          complex_data_type_name: "lightning__objectType"\n`,
         `        result: object\n          description: "bare object output"\n`
       )
     );
-    const errors = diagnostics.filter(
+    const primitiveWarnings = diagnostics.filter(
       d => d.code === 'complex-data-type-on-primitive'
     );
-    const warnings = diagnostics.filter(
+    const missingSchemaWarnings = diagnostics.filter(
       d => d.code === 'object-type-missing-schema'
     );
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain("'amount'");
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toContain("'result'");
+    expect(primitiveWarnings).toHaveLength(1);
+    expect(primitiveWarnings[0].severity).toBe(DiagnosticSeverity.Warning);
+    expect(primitiveWarnings[0].message).toContain("'amount'");
+    expect(missingSchemaWarnings).toHaveLength(1);
+    expect(missingSchemaWarnings[0].message).toContain("'result'");
   });
 });


### PR DESCRIPTION
## What

Refines the `complex-data-type` lint pass for Agentforce so it correctly handles primitive types, and adds focused test coverage for the new behavior.

## Why

`complex_data_type_name` is only meaningful for `object` and `list[object]`. Previously:

- The rule warned when `object` / `list[object]` declarations *lacked* `complex_data_type_name` / `schema`.
- It said nothing when a **primitive** type (e.g. `number`, `string`, `id`) was declared *with* a `complex_data_type_name`, even though that combination is invalid.
- anything other than `object` and `list` does not need a `complex_data_type_name` to validate — so specifying one on a primitive should be a hard error.

## How

**[dialect/agentforce/src/lint/passes/complex-data-type.ts](dialect/agentforce/src/lint/passes/complex-data-type.ts)**

- Renamed `isObjectType` → `isComplexType`, backed by a named set `REQURIED_COMPLEX_DATA_TYPE = { object, list[object] }`. Anything outside the set is treated as primitive.
- Merged `checkInputs` and `checkOutputs` into a single `checkDecls(decls, actionName, kind)` to remove duplication; `kind` (`'input' | 'output'`) only shapes the diagnostic message and gates the input-only `schema:` escape hatch.
- Added a new diagnostic code **`complex-data-type-on-primitive`** (Error severity): emitted when a non-whitelisted type carries a `complex_data_type_name`.
- Kept the existing **`object-type-missing-schema`** (Warning) for whitelisted types missing schema info.
- Updated the file-level doc comment to describe both diagnostics.

Notable design decisions:
- `list[<primitive>]` is intentionally classified as primitive (`list[object]` is the only list variant that supports `complex_data_type_name`).
- `schema:` remains an alternative to `complex_data_type_name` for inputs only; outputs still require `complex_data_type_name`.
- "ID should be deprecated" was scoped out — that belongs in a separate pass.

**[dialect/agentforce/src/tests/lint.test.ts](dialect/agentforce/src/tests/lint.test.ts)**

Added a `describe('complex data type rule', …)` block with a `wrap(inputs, outputs)` helper that builds a minimal `subagent` AfScript fixture, plus these scenarios:

| # | Scenario | Expected |
|---|---|---|
| 1 | primitive (`number`) input + `complex_data_type_name` | Error `complex-data-type-on-primitive` |
| 2 | primitive (`number`) input, no `complex_data_type_name` | no error |
| 3 | primitive (`string`) output + `complex_data_type_name` | Error |
| 4 | `it.each` over `boolean`, `integer`, `id`, `date`, `datetime`, `time`, `timestamp`, `currency`, `long` with `complex_data_type_name` | Error per case |
| 5 | `object` input + `complex_data_type_name` | no diagnostic |
| 6 | `object` input + `schema:` | no diagnostic |
| 7 | `list[object]` output + `complex_data_type_name` | no diagnostic |
| 8 | `list[string]` input + `complex_data_type_name` | Error (list-of-primitive treated as primitive) |
| 9 | mixed: primitive-with-cdtn input + bare `object` output | both Error and Warning fire with correct names |

## Test Plan

- [x] Existing tests pass — `pnpm vitest run src/tests/lint.test.ts` → **125 passed**, including the pre-existing `'warns with actions:'` warning case.
- [x] New tests cover the change — see scenarios 1-9 above.
- [x] Type checks pass — `pnpm typecheck` clean (no `pnpm lint` script in this package).

## Checklist

- [x] My code follows the project's coding style
- [x] I have reviewed my own diff (`git diff main` — 2 files, 223 insertions / 43 deletions; logic isolated to `complex-data-type.ts` and tests)
- [ ] I have added/updated documentation as needed *(updated only the file-level JSDoc on the lint pass; no external docs reference this rule)*
- [x] This change does not introduce new warnings

