### PR TITLE
test(language/lint): add unit tests for empty-block pass

### DIFF
--- a/packages/language/src/lint/empty-block.test.ts
+++ b/packages/language/src/lint/empty-block.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * For full license text, see the LICENSE file in the repo root or https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse } from '@agentscript/parser';
+import { Dialect } from '../core/dialect.js';
+import { LintEngine } from '../core/analysis/lint-engine.js';
+import { createSchemaContext } from '../core/analysis/scope.js';
+import { ActionsBlock } from '../blocks.js';
+import { emptyBlockPass } from './empty-block.js';
+
+const TestSchema = {
+  actions: ActionsBlock,
+};
+
+const schemaCtx = createSchemaContext({ schema: TestSchema, aliases: {} });
+
+function getDiagnostics(source: string, code?: string) {
+  const { rootNode: root } = parse(source);
+  const mappingNode =
+    root.namedChildren.find(n => n.type === 'mapping') ?? root;
+
+  const dialect = new Dialect();
+  const result = dialect.parse(mappingNode, TestSchema);
+
+  const engine = new LintEngine({
+    passes: [emptyBlockPass()],
+    source: 'test',
+  });
+  const { diagnostics } = engine.run(result.value, schemaCtx);
+  if (!code) return diagnostics;
+  return diagnostics.filter(d => d.code === code);
+}
+
+describe('empty-block lint pass', () => {
+  it('flags a bare `inputs:` with no entries', () => {
+    const diags = getDiagnostics(
+      `
+actions:
+  Lookup:
+    description: "Look something up"
+    target: "flow://Lookup"
+    inputs:
+`,
+      'empty-block'
+    );
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain('inputs');
+  });
+
+  it('does not flag a populated `inputs:` block', () => {
+    const diags = getDiagnostics(
+      `
+actions:
+  Lookup:
+    description: "Look something up"
+    target: "flow://Lookup"
+    inputs:
+      query: string
+`,
+      'empty-block'
+    );
+    expect(diags).toHaveLength(0);
+  });
+
+  it('flags a bare `outputs:` with no entries', () => {
+    const diags = getDiagnostics(
+      `
+actions:
+  Lookup:
+    description: "Look something up"
+    target: "flow://Lookup"
+    outputs:
+`,
+      'empty-block'
+    );
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain('outputs');
+  });
+
+  it('reports two diagnostics when both `inputs:` and `outputs:` are empty', () => {
+    const diags = getDiagnostics(
+      `
+actions:
+  Lookup:
+    description: "x"
+    target: "flow://Lookup"
+    inputs:
+    outputs:
+`,
+      'empty-block'
+    );
+    expect(diags).toHaveLength(2);
+  });
+
+  it('reports one diagnostic per action when multiple actions have empty blocks', () => {
+    const diags = getDiagnostics(
+      `
+actions:
+  Alpha:
+    description: "a"
+    target: "flow://Alpha"
+    inputs:
+  Beta:
+    description: "b"
+    target: "flow://Beta"
+    inputs:
+      x: string
+  Gamma:
+    description: "g"
+    target: "flow://Gamma"
+    outputs:
+`,
+      'empty-block'
+    );
+    expect(diags).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## What

Adds 5 unit tests for the `empty-block` lint pass in `packages/language/src/lint/empty-block.ts`. Brings the rule's test count from 0 to 5.

## Why

The `empty-block` rule flags empty `inputs:` and `outputs:` blocks (a common authoring mistake) but had no tests pinning down its behavior. This change closes the gap using the same pattern PR #38 (`required-fields.test.ts`) established for lint-rule tests.

## How

New test file at `packages/language/src/lint/empty-block.test.ts` using vitest. Follows `required-fields.test.ts` exactly: single `describe` block, flat `it` cases, shared `getDiagnostics` helper, `ActionsBlock`-based test schema.

The 5 cases:

1. Flags a bare `inputs:` with no entries
2. Does not flag a populated `inputs:` block
3. Flags a bare `outputs:` with no entries
4. Reports two diagnostics when both `inputs:` and `outputs:` are empty
5. Reports one diagnostic per action when multiple actions have empty blocks

## Test Plan

```
pnpm --filter @agentscript/language test empty-block
```

Result:

```
✓ src/lint/empty-block.test.ts (5 tests) 11ms
Test Files  1 passed (1)
     Tests  5 passed (5)
```

- [x] `pnpm --filter @agentscript/language test empty-block` — 5/5 passing
- [x] `npx eslint --config eslint.config.js packages/language/src/lint/empty-block.test.ts` — exit 0
- [ ] New/updated tests cover the change — N/A (this PR *is* the tests)

## Checklist

- [x] My code follows the project's coding style
- [x] I have reviewed my own diff
- [x] I have added/updated documentation as needed
- [x] This change does not introduce new warnings
