### PR TITLE
feat(agentfabric): release dialect v0.4.0

### DIFF
--- a/dialect/agentfabric/CHANGELOG.md
+++ b/dialect/agentfabric/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @agentscript/agentfabric-dialect
 
+## 0.4.0
+
+### Breaking Changes
+
+- Redesigned the `echo` node around A2A v1 task-update events. The single `kind: "a2a:response"` variant is replaced by two event variants:
+
+  - `a2a:status_update_event` — sets the task `state` (required; one of the A2A v1 `TASK_STATE_*` values) with an optional `message`.
+  - `a2a:artifact_update_event` — emits an `artifact` (required) with optional `append` and `lastChunk` flags.
+
+  The base `task` and `artifacts` fields and the `a2a.task` namespaced function have been removed. Flows using `kind: "a2a:response"`, `task:`, `artifacts:`, or `a2a.task(...)` must migrate to the new event variants.
+
+### Minor Changes
+
+- Added the `terminal-requires-status-update` lint rule: every terminal branch in a graph must reach an `a2a:status_update_event` echo that sets a terminal state (`TASK_STATE_COMPLETED`, `TASK_STATE_FAILED`, or `TASK_STATE_CANCELED`). The echo need not be the leaf node.
+- Added the `echo-invalid-state` lint rule, which validates that an `a2a:status_update_event` echo's `state` is a known A2A v1 task state.
+- Exported `A2A_TASK_STATES` and `A2A_TERMINAL_STATES` from the schema for shared use across the schema, compiler, and linter.
+- Removed the `echo-task-or-message-required` rule, which no longer applies under the new event model.
+
 ## 0.1.24
 
 ### Patch Changes

--- a/dialect/agentfabric/package.json
+++ b/dialect/agentfabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentscript/agentfabric-dialect",
-  "version": "0.1.30",
+  "version": "0.4.0",
   "description": "AgentFabric dialect — schema, lint rules, compiler, and dialect config",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bump @agentscript/agentfabric-dialect to 0.4.0 and add the changelog entry.

Breaking: redesign the echo node around A2A v1 task-update events. The a2a:response variant is replaced by a2a:status_update_event and a2a:artifact_update_event; the task/artifacts fields and the a2a.task function are removed.

Adds the terminal-requires-status-update and echo-invalid-state lint rules, exports A2A_TASK_STATES and A2A_TERMINAL_STATES from the schema, and removes the now-obsolete echo-task-or-message-required rule.

## What

<!-- A brief description of the change. -->

## Why

<!-- Why is this change needed? Link to a GitHub Issue if applicable (e.g. Fixes #123). -->

## How

<!-- How was this implemented? Call out any notable design decisions. -->

## Test Plan

<!-- How did you verify this change? -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New/updated tests cover the change
- [ ] Linting and type checks pass (`pnpm lint && pnpm typecheck`)

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have reviewed my own diff
- [ ] I have added/updated documentation as needed
- [ ] This change does not introduce new warnings
