### PR TITLE
test(language/lint): add unit tests for unused-variable pass

### DIFF
--- a/packages/language/src/lint/unused-variable.test.ts
+++ b/packages/language/src/lint/unused-variable.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * For full license text, see the LICENSE file in the repo root or https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse } from '@agentscript/parser';
+import { Dialect } from '../core/dialect.js';
+import { NamedBlock, NamedCollectionBlock } from '../core/block.js';
+import { ExpressionValue } from '../core/primitives.js';
+import { LintEngine } from '../core/analysis/lint-engine.js';
+import { createSchemaContext } from '../core/analysis/scope.js';
+import { VariablesBlock } from '../blocks.js';
+import { unusedVariablePass } from './unused-variable.js';
+
+const ValueBlock = NamedBlock('ValueBlock', {
+  expr: ExpressionValue.describe('An expression that may reference variables'),
+});
+
+const TestSchema = {
+  variables: VariablesBlock,
+  value: NamedCollectionBlock(ValueBlock),
+};
+
+const schemaCtx = createSchemaContext({ schema: TestSchema, aliases: {} });
+
+function getDiagnostics(source: string) {
+  const { rootNode: root } = parse(source);
+  const mappingNode =
+    root.namedChildren.find(n => n.type === 'mapping') ?? root;
+
+  const dialect = new Dialect();
+  const result = dialect.parse(mappingNode, TestSchema);
+
+  const engine = new LintEngine({
+    passes: [unusedVariablePass()],
+    source: 'test',
+  });
+  const { diagnostics } = engine.run(result.value, schemaCtx);
+  return diagnostics.filter(d => d.code === 'unused-variable');
+}
+
+describe('unused-variable lint pass', () => {
+  it('flags a variable that is declared but never referenced', () => {
+    const diags = getDiagnostics(`
+variables:
+    unused: mutable string = ""
+`);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain('unused');
+  });
+
+  it('does not flag a variable that is referenced in an expression', () => {
+    const diags = getDiagnostics(`
+variables:
+    used: mutable string = ""
+
+value v:
+    expr: @variables.used
+`);
+    expect(diags).toHaveLength(0);
+  });
+
+  it('flags only the unused variables when multiple are declared', () => {
+    const diags = getDiagnostics(`
+variables:
+    used: mutable string = ""
+    unused: mutable string = ""
+
+value v:
+    expr: @variables.used
+`);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain('unused');
+  });
+
+  it('reports one diagnostic per unused variable', () => {
+    const diags = getDiagnostics(`
+variables:
+    a: mutable string = ""
+    b: mutable string = ""
+    c: mutable string = ""
+`);
+    expect(diags).toHaveLength(3);
+  });
+
+  it('does not flag variables when no `variables:` block is declared', () => {
+    const diags = getDiagnostics(`
+value v:
+    expr: @variables.foo
+`);
+    expect(diags).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Adds 5 unit tests for the `unused-variable` lint pass in `packages/language/src/lint/unused-variable.ts`. Brings the rule's test count from 0 to 5.

## Why

The `unused-variable` rule flags variables declared in the `variables:` block that are never referenced via `@variables.<name>` expressions, but had no tests pinning down its behavior. This closes the gap using the same pattern PRs #38 (`required-fields.test.ts`) and #48 (`empty-block.test.ts`) established for single-rule lint tests.

## How

New test file at `packages/language/src/lint/unused-variable.test.ts` using vitest. Follows `empty-block.test.ts` exactly: single `describe` block, flat `it` cases, shared `getDiagnostics` helper. The test schema combines `VariablesBlock` (for variable declarations) with a small custom `ValueBlock` whose `expr: ExpressionValue` field provides somewhere for expressions to reference those variables.

The 5 cases:

1. Flags a variable that is declared but never referenced
2. Does not flag a variable that is referenced in an expression
3. Flags only the unused variables when multiple are declared
4. Reports one diagnostic per unused variable
5. Does not flag variables when no `variables:` block is declared

## Test Plan

```
pnpm --filter @agentscript/language test unused-variable
```

Result:

```
✓ src/lint/unused-variable.test.ts (5 tests) 6ms
Test Files  1 passed (1)
     Tests  5 passed (5)
```

- [x] `pnpm --filter @agentscript/language test unused-variable` — 5/5 passing
- [x] `npx eslint --config eslint.config.js packages/language/src/lint/unused-variable.test.ts` — exit 0
- [ ] New/updated tests cover the change — N/A (this PR *is* the tests)

## Checklist

- [x] My code follows the project's coding style
- [x] I have reviewed my own diff
- [x] I have added/updated documentation as needed
- [x] This change does not introduce new warnings
