### PR TITLE
test(language/lint): add unit tests for unreachable-code pass

### DIFF
--- a/packages/language/src/lint/unreachable-code.test.ts
+++ b/packages/language/src/lint/unreachable-code.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * For full license text, see the LICENSE file in the repo root or https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse } from '@agentscript/parser';
+import { Dialect } from '../core/dialect.js';
+import { NamedBlock, NamedCollectionBlock } from '../core/block.js';
+import { StringValue, ProcedureValue } from '../core/primitives.js';
+import { LintEngine } from '../core/analysis/lint-engine.js';
+import { createSchemaContext } from '../core/analysis/scope.js';
+import { unreachableCodePass } from './unreachable-code.js';
+
+const ProcBlock = NamedBlock('ProcBlock', {
+  label: StringValue.describe('Label'),
+  body: ProcedureValue.describe('Procedure body'),
+});
+
+const TestSchema = {
+  proc: NamedCollectionBlock(ProcBlock),
+};
+
+const schemaCtx = createSchemaContext({ schema: TestSchema, aliases: {} });
+
+function getDiagnostics(source: string) {
+  const { rootNode: root } = parse(source);
+  const mappingNode =
+    root.namedChildren.find(n => n.type === 'mapping') ?? root;
+
+  const dialect = new Dialect();
+  const result = dialect.parse(mappingNode, TestSchema);
+
+  const engine = new LintEngine({
+    passes: [unreachableCodePass()],
+    source: 'test',
+  });
+  const { diagnostics } = engine.run(result.value, schemaCtx);
+  return diagnostics.filter(d => d.code === 'unreachable-code');
+}
+
+describe('unreachable-code lint pass', () => {
+  it('flags code after a transition', () => {
+    const diags = getDiagnostics(`
+proc one:
+  label: "one"
+  body: ->
+    transition to @subagent.next
+    | this line is unreachable
+`);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain('transition');
+  });
+
+  it('does not flag a procedure whose last statement is a transition', () => {
+    const diags = getDiagnostics(`
+proc one:
+  label: "one"
+  body: ->
+    | greet the user
+    transition to @subagent.next
+`);
+    expect(diags).toHaveLength(0);
+  });
+
+  it('flags code after an if/else where both branches transition', () => {
+    const diags = getDiagnostics(`
+proc one:
+  label: "one"
+  body: ->
+    if @variables.x == "a":
+      transition to @subagent.left
+    else:
+      transition to @subagent.right
+    | this line is unreachable
+`);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain("'if'");
+  });
+
+  it('does not flag code after an if/else where only one branch transitions', () => {
+    const diags = getDiagnostics(`
+proc one:
+  label: "one"
+  body: ->
+    if @variables.x == "a":
+      transition to @subagent.left
+    else:
+      | stay here
+    | this line still runs in the else case
+`);
+    expect(diags).toHaveLength(0);
+  });
+
+  it('flags unreachable code inside a nested if body', () => {
+    const diags = getDiagnostics(`
+proc one:
+  label: "one"
+  body: ->
+    if @variables.x == "a":
+      transition to @subagent.left
+      | unreachable inside the if
+    | still reachable here
+`);
+    expect(diags).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

Adds 5 unit tests for the `unreachable-code` lint pass in `packages/language/src/lint/unreachable-code.ts`. Brings the rule's test count from 0 to 5.

## Why

The `unreachable-code` rule flags code that follows a terminal statement — either a bare `transition` or an `if/else` block where all branches transition. It had no tests pinning down its behavior. This closes the gap using the same pattern PRs #38 (`required-fields.test.ts`), #48 (`empty-block.test.ts`), and #60 (`unused-variable.test.ts`) established for single-rule lint tests.

## How

New test file at `packages/language/src/lint/unreachable-code.test.ts` using vitest. Follows `unsupported-conditionals.test.ts` exactly: single `describe` block, flat `it` cases, shared `getDiagnostics` helper, and the same `ProcBlock` / `ProcedureValue` schema shape so the procedural fixtures parse correctly.

The 5 cases:

1. Flags code after a `transition`
2. Does not flag a procedure whose last statement is a transition
3. Flags code after an `if/else` where both branches transition
4. Does not flag code after an `if/else` where only one branch transitions
5. Flags unreachable code inside a nested if body

## Test Plan

```
pnpm --filter @agentscript/language test unreachable-code
```

Result:

```
✓ src/lint/unreachable-code.test.ts (5 tests) 7ms
Test Files  1 passed (1)
     Tests  5 passed (5)
```

- [x] `pnpm --filter @agentscript/language test unreachable-code` — 5/5 passing
- [x] `npx eslint --config eslint.config.js packages/language/src/lint/unreachable-code.test.ts` — exit 0
- [ ] New/updated tests cover the change — N/A (this PR *is* the tests)

## Checklist

- [x] My code follows the project's coding style
- [x] I have reviewed my own diff
- [x] I have added/updated documentation as needed
- [x] This change does not introduce new warnings
